### PR TITLE
Remove C strings, add anonymous container literals

### DIFF
--- a/grammar/grammar.y
+++ b/grammar/grammar.y
@@ -121,6 +121,7 @@ PrimaryTypeExpr
      / CHAR_LITERAL
      / ContainerDecl
      / DOT IDENTIFIER
+     / DOT InitList
      / ErrorSetDecl
      / FLOAT
      / FnProto
@@ -347,7 +348,6 @@ string_char
 
 line_comment <- '//'[^\n]*
 line_string <- ("\\\\" [^\n]* [ \n]*)+
-line_cstring <- ("c\\\\" [^\n]* [ \n]*)+
 skip <- ([ \n] / line_comment)*
 
 CHAR_LITERAL <- "'" char_char "'" skip
@@ -362,11 +362,10 @@ INTEGER
      / "0x" hex+   skip
      /      [0-9]+ skip
 STRINGLITERAL
-    <- "c"? "\"" string_char* "\"" skip
+    <- "\"" string_char* "\"" skip
      / line_string                 skip
-     / line_cstring                skip
 IDENTIFIER
-    <- !keyword ("c" !["\\] / [A-Zabd-z_]) [A-Za-z0-9_]* skip
+    <- !keyword [A-Za-z_] [A-Za-z0-9_]* skip
      / "@\"" string_char* "\""                            skip
 BUILTINIDENTIFIER <- "@"[A-Za-z_][A-Za-z0-9_]* skip
 


### PR DESCRIPTION
Implementation of container literals:
- [stage 1](https://github.com/ziglang/zig/commit/de30438ed2efb909538f3177cced441b57eb1a5d#diff-bd8f167953cc43fb7cba7d420fbd1d48)
- [stage2](https://github.com/ziglang/zig/commit/d4e6a6d5e27df845d47b254aab9d14f44d68d620#diff-065b15c4e7f1fcc25b5f2d0b98796e53)

Implementation of removal of C strings:
- [stage 1](https://github.com/ziglang/zig/commit/47f06be36943f808aa9798c19172363afe6ae35c#diff-bd8f167953cc43fb7cba7d420fbd1d48)

Tested against build.zig in the root directory of the Zig compiler on master.