### PR TITLE
Use $(CC) instead of cc as C compiler

### DIFF
--- a/grammar/Makefile
+++ b/grammar/Makefile
@@ -14,7 +14,7 @@ build/full.c: main.c build/parser.c
 	cat $^ > $@
 
 build/parser: build/full.c
-	cc -O3 -o $@ $^
+	$(CC) -O3 -o $@ $^
 
 build/parser_debug: build/full.c
-	cc -O3 -o $@ $^ -DYY_DEBUG
+	$(CC) -O3 -o $@ $^ -DYY_DEBUG


### PR DESCRIPTION
$(CC) should be used instead of `cc` directly. It defaults to `cc`,
so just running `make` has the same behavior as before. However this
makes it easy for the user to use a different C compiler via the CC
environment variable.