### PR TITLE
better error messages from check_parser.sh

### DIFF
--- a/grammar/Makefile
+++ b/grammar/Makefile
@@ -1,5 +1,5 @@
-
-all: build build/parser build/parser_debug
+.PHONY: all clean
+all: build/parser build/parser_debug
 
 clean:
 	rm -r build
@@ -7,7 +7,7 @@ clean:
 build:
 	mkdir build
 
-build/parser.c: grammar.y
+build/parser.c: grammar.y | build
 	peg $^ > $@
 
 build/full.c: main.c build/parser.c

--- a/grammar/check_parser.sh
+++ b/grammar/check_parser.sh
@@ -1,22 +1,36 @@
 #!/usr/bin/env bash
 
+if [ ! -x ./build/parser ]; then
+	echo 'ERROR: ./build/parser: not found.'
+	echo 'ERROR: you need to run `make` first.'
+	exit 1
+fi
+
 ZIG=${ZIG:-zig}
 
 if [ $# -eq 0 ]; then
-	FILE_LIST=(./tests/*.zig)
-	FILES="${FILE_LIST[@]}"
+	FILES=(tests/*.zig)
 else
-	FILES="$@"
+	FILES=("$@")
 fi
 
-for FILE in $FILES
-do
-	$ZIG fmt --stdin < $FILE > /dev/null 2>&1
+echo "running ${#FILES[@]} tests..."
+
+ANY_FAILURE=
+for FILE in "${FILES[@]}"; do
+	$ZIG fmt --stdin < "$FILE" > /dev/null 2>&1
 	zigret=$?
-	./build/parser < $FILE > /dev/null 2>&1
+	./build/parser < "$FILE" > /dev/null 2>&1
 	parserret=$?
 
 	if [ "$zigret" -ne "$parserret" ]; then
-		echo "$FILE"
+		echo "FAIL: ${FILE}: zig: $zigret, grammar: $parserret"
+		ANY_FAILURE=1
 	fi
 done
+
+if [ -z "$ANY_FAILURE" ]; then
+	echo 'all tests passed'
+else
+	exit 1
+fi


### PR DESCRIPTION
* `./check_parser.sh` will give an error if `build/parser` is not found. that means you need to run make.
* `./check_parser.sh` uses proper bash arrays for the `FILES` variable. this is required in case any of the file names have spaces in them.
* `./check_parser.sh` says how many tests are going to be run so that you have some sense of what you're waiting for.
* `./check_parser.sh` says "FAIL" for each failed test instead of just printing the name. Also shows the reason for failure.
* `./check_parser.sh` says "all tests passed" when they all pass.

This all came out of a usage confusion i had when i ran the script and it printed a bunch of tests to stdout. i thought it was telling me they all succeeded when really it was failing due to `build/parser` not even existing ( ͡° ͜ʖ ͡°). The output is much clearer now.

also:
* `Makefile` lists the `build` directory as an "exist only" dependency of the first build artifact. This fixes the use case `make build/parser` when the `build` directory doesn't exist.
* `Makefile` lists `all` and `clean` as `.PHONY`, which is "best practice" or whatever in case someone creates file system objects that match those names.