### PR TITLE
gh actions check_parser

### DIFF
--- a/.github/workflows/check_parser.yml
+++ b/.github/workflows/check_parser.yml
@@ -1,0 +1,28 @@
+name: continuous audit
+
+on:
+  push:
+  schedule:
+    - cron: '10 1 * * *'
+  workflow_dispatch:
+
+jobs:
+  npm-run-build-templates:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: check_parser.sh
+        run: |
+          pushd grammar
+            PEG_VERSION=peg-0.1.18
+            wget https://www.piumarta.com/software/peg/$PEG_VERSION.tar.gz
+            tar zxf $PEG_VERSION.tar.gz
+            rm $PEG_VERSION.tar.gz
+            pushd $PEG_VERSION
+              make
+            popd
+            export PATH=$PEG_VERSION:$PATH
+            make
+            ./check_parser.sh
+          popd
+


### PR DESCRIPTION
There are compiler warnings when building peg. You should be able to start a gh run in the pr if it has not already happened for you, and see those warnings. Do you also get these warnings?

I do not think any of the 89 tests passed.