### PR TITLE
Container doc comments only valid at start of containers

### DIFF
--- a/grammar/grammar.y
+++ b/grammar/grammar.y
@@ -1,8 +1,8 @@
-Root <- skip ContainerMembers eof
+Root <- skip container_doc_comment? ContainerMembers eof
 
 # *** Top level ***
 ContainerMembers
-    <- container_doc_comment? (
+    <- (
          TestDecl ContainerMembers
          / TopLevelComptime ContainerMembers
          / doc_comment? KEYWORD_pub? TopLevelDecl ContainerMembers
@@ -306,7 +306,7 @@ PtrTypeStart
      / LBRACKET ASTERISK (LETTERC / COLON Expr)? RBRACKET
 
 # ContainerDecl specific
-ContainerDeclAuto <- ContainerDeclType LBRACE ContainerMembers RBRACE
+ContainerDeclAuto <- ContainerDeclType LBRACE container_doc_comment? ContainerMembers RBRACE
 
 ContainerDeclType
     <- KEYWORD_struct

--- a/grammar/tests/doc_comments.zig
+++ b/grammar/tests/doc_comments.zig
@@ -10,8 +10,6 @@ const MyStruct = struct {
     /// This is another doc comment
     b: i32,
 
-    //! Resuming container doc comment
-
     /// And one more field
     c: f32,
 };
@@ -22,12 +20,10 @@ const MyEnum = enum {
 
     /// This is Foo
     Foo,
-    //! It has some other fields
     /// This is Bar
     Bar,
 };
 
-//! This is a container doc comment outside an error block
 /// This is a doc comment for the error block
 const Errors = error {
     /// This documents MyError1
@@ -55,7 +51,6 @@ comptime {
     const foo = add(40, 2);
 }
 
-//! This is container doc comment
 /// This is a doc comment for a test
 test "This is my test" {
 }

--- a/grammar/tests/invalid_doc_comments.zig
+++ b/grammar/tests/invalid_doc_comments.zig
@@ -1,0 +1,7 @@
+//! This is a valid container doc comment
+
+const Foo = struct {
+    //! This is a valid container doc comment
+};
+
+//! This is an invalid container doc comment


### PR DESCRIPTION
This behavior was changed in https://github.com/ziglang/zig/pull/7920