### PR TITLE
Change grammar to require or disallow types on fields for different containers

### DIFF
--- a/grammar/grammar.y
+++ b/grammar/grammar.y
@@ -1,15 +1,13 @@
 Root <- skip container_doc_comment? ContainerMembers eof
 
 # *** Top level ***
-ContainerMembers
-    <- (
-         TestDecl ContainerMembers
-         / TopLevelComptime ContainerMembers
-         / doc_comment? KEYWORD_pub? TopLevelDecl ContainerMembers
-         / ContainerField COMMA ContainerMembers
-         / ContainerField
-         /
-     )
+ContainerMembers <- ContainerDeclarations ContainerFieldList ContainerDeclarations
+
+ContainerDeclarations
+    <- TestDecl ContainerDeclarations
+     / TopLevelComptime ContainerDeclarations
+     / doc_comment? KEYWORD_pub? TopLevelDecl ContainerDeclarations
+     /
 
 TestDecl <- doc_comment? KEYWORD_test STRINGLITERALSINGLE? Block
 
@@ -334,6 +332,8 @@ StringList <- (STRINGLITERAL COMMA)* STRINGLITERAL?
 ParamDeclList <- (ParamDecl COMMA)* ParamDecl?
 
 ExprList <- (Expr COMMA)* Expr?
+
+ContainerFieldList <- (ContainerField COMMA)* ContainerField?
 
 # *** Tokens ***
 eof <- !.

--- a/grammar/grammar.y
+++ b/grammar/grammar.y
@@ -1,9 +1,13 @@
-Root <- skip container_doc_comment? ContainerMembers eof
+Root <- skip container_doc_comment? StructMembers eof
 
 # *** Top level ***
-ContainerMembers <- ContainerDeclarations ContainerFieldList ContainerDeclarations
+StructMembers <- ContainerDeclarations StructFieldList ContainerDeclarations
 
-TaggedUnionMembers <- ContainerDeclarations TaggedUnionFieldList ContainerDeclarations
+BareUnionMembers <- ContainerDeclarations BareUnionFieldList ContainerDeclarations
+
+InferredTagUnionMembers <- ContainerDeclarations InferredTagUnionFieldList ContainerDeclarations
+
+ExplicitTagUnionMembers <- ContainerDeclarations ExplicitTagUnionFieldList ContainerDeclarations
 
 EnumMembers <- ContainerDeclarations EnumFieldList ContainerDeclarations
 
@@ -26,9 +30,13 @@ FnProto <- KEYWORD_fn IDENTIFIER? LPAREN ParamDeclList RPAREN ByteAlign? LinkSec
 
 VarDecl <- (KEYWORD_const / KEYWORD_var) IDENTIFIER (COLON TypeExpr)? ByteAlign? LinkSection? (EQUAL Expr)? SEMICOLON
 
-ContainerField <- doc_comment? KEYWORD_comptime? IDENTIFIER COLON (KEYWORD_anytype / TypeExpr) ByteAlign? (EQUAL Expr)?
+StructField <- doc_comment? KEYWORD_comptime? IDENTIFIER COLON (KEYWORD_anytype / TypeExpr) ByteAlign? (EQUAL Expr)?
 
-TaggedUnionField <- doc_comment? KEYWORD_comptime? IDENTIFIER (COLON (KEYWORD_anytype / TypeExpr) ByteAlign?)? (EQUAL Expr)?
+BareUnionField <- doc_comment? IDENTIFIER COLON (KEYWORD_anytype / TypeExpr) ByteAlign?
+
+InferredTagUnionField <- doc_comment? IDENTIFIER (COLON (KEYWORD_anytype / TypeExpr) ByteAlign?)? (EQUAL Expr)?
+
+ExplicitTagUnionField <- doc_comment? IDENTIFIER (COLON (KEYWORD_anytype / TypeExpr) ByteAlign?)?
 
 EnumField <- doc_comment? IDENTIFIER (EQUAL Expr)?
 
@@ -316,10 +324,11 @@ ArrayTypeStart <- LBRACKET Expr (COLON Expr)? RBRACKET
 
 # ContainerDecl specific
 ContainerDeclAuto
-    <- KEYWORD_struct LBRACE container_doc_comment? ContainerMembers RBRACE
+    <- KEYWORD_struct LBRACE container_doc_comment? StructMembers RBRACE
      / KEYWORD_opaque LBRACE container_doc_comment? ContainerDeclarations RBRACE
-     / KEYWORD_union LPAREN (KEYWORD_enum (LPAREN Expr RPAREN)? / Expr) RPAREN LBRACE container_doc_comment? TaggedUnionMembers RBRACE
-     / KEYWORD_union LBRACE container_doc_comment? ContainerMembers RBRACE
+     / KEYWORD_union LBRACE container_doc_comment? BareUnionMembers RBRACE
+     / KEYWORD_union LPAREN KEYWORD_enum (LPAREN Expr RPAREN)? RPAREN LBRACE container_doc_comment? InferredTagUnionMembers RBRACE
+     / KEYWORD_union LPAREN Expr RPAREN LBRACE container_doc_comment? ExplicitTagUnionMembers RBRACE
      / KEYWORD_enum (LPAREN Expr RPAREN)? LBRACE container_doc_comment? EnumMembers RBRACE
 
 # Alignment
@@ -340,9 +349,13 @@ ParamDeclList <- (ParamDecl COMMA)* ParamDecl?
 
 ExprList <- (Expr COMMA)* Expr?
 
-ContainerFieldList <- (ContainerField COMMA)* ContainerField?
+StructFieldList <- (StructField COMMA)* StructField?
 
-TaggedUnionFieldList <- (TaggedUnionField COMMA)* TaggedUnionField?
+BareUnionFieldList <- (BareUnionField COMMA)* BareUnionField?
+
+InferredTagUnionFieldList <- (InferredTagUnionField COMMA)* InferredTagUnionField?
+
+ExplicitTagUnionFieldList <- (ExplicitTagUnionField COMMA)* ExplicitTagUnionField?
 
 EnumFieldList <- (EnumField COMMA)* EnumField?
 

--- a/grammar/grammar.y
+++ b/grammar/grammar.y
@@ -3,6 +3,8 @@ Root <- skip container_doc_comment? ContainerMembers eof
 # *** Top level ***
 ContainerMembers <- ContainerDeclarations ContainerFieldList ContainerDeclarations
 
+TaggedUnionMembers <- ContainerDeclarations TaggedUnionFieldList ContainerDeclarations
+
 EnumMembers <- ContainerDeclarations EnumFieldList ContainerDeclarations
 
 ContainerDeclarations
@@ -25,6 +27,8 @@ FnProto <- KEYWORD_fn IDENTIFIER? LPAREN ParamDeclList RPAREN ByteAlign? LinkSec
 VarDecl <- (KEYWORD_const / KEYWORD_var) IDENTIFIER (COLON TypeExpr)? ByteAlign? LinkSection? (EQUAL Expr)? SEMICOLON
 
 ContainerField <- doc_comment? KEYWORD_comptime? IDENTIFIER COLON (KEYWORD_anytype / TypeExpr) ByteAlign? (EQUAL Expr)?
+
+TaggedUnionField <- doc_comment? KEYWORD_comptime? IDENTIFIER (COLON (KEYWORD_anytype / TypeExpr) ByteAlign?)? (EQUAL Expr)?
 
 EnumField <- doc_comment? IDENTIFIER (EQUAL Expr)?
 
@@ -312,13 +316,11 @@ ArrayTypeStart <- LBRACKET Expr (COLON Expr)? RBRACKET
 
 # ContainerDecl specific
 ContainerDeclAuto
-    <- ContainerDeclType LBRACE container_doc_comment? ContainerMembers RBRACE
+    <- KEYWORD_struct LBRACE container_doc_comment? ContainerMembers RBRACE
+     / KEYWORD_opaque LBRACE container_doc_comment? ContainerDeclarations RBRACE
+     / KEYWORD_union LPAREN (KEYWORD_enum (LPAREN Expr RPAREN)? / Expr) RPAREN LBRACE container_doc_comment? TaggedUnionMembers RBRACE
+     / KEYWORD_union LBRACE container_doc_comment? ContainerMembers RBRACE
      / KEYWORD_enum (LPAREN Expr RPAREN)? LBRACE container_doc_comment? EnumMembers RBRACE
-
-ContainerDeclType
-    <- KEYWORD_struct
-     / KEYWORD_opaque
-     / KEYWORD_union (LPAREN (KEYWORD_enum (LPAREN Expr RPAREN)? / Expr) RPAREN)?
 
 # Alignment
 ByteAlign <- KEYWORD_align LPAREN Expr RPAREN
@@ -339,6 +341,8 @@ ParamDeclList <- (ParamDecl COMMA)* ParamDecl?
 ExprList <- (Expr COMMA)* Expr?
 
 ContainerFieldList <- (ContainerField COMMA)* ContainerField?
+
+TaggedUnionFieldList <- (TaggedUnionField COMMA)* TaggedUnionField?
 
 EnumFieldList <- (EnumField COMMA)* EnumField?
 

--- a/grammar/grammar.y
+++ b/grammar/grammar.y
@@ -3,6 +3,8 @@ Root <- skip container_doc_comment? ContainerMembers eof
 # *** Top level ***
 ContainerMembers <- ContainerDeclarations ContainerFieldList ContainerDeclarations
 
+EnumMembers <- ContainerDeclarations EnumFieldList ContainerDeclarations
+
 ContainerDeclarations
     <- TestDecl ContainerDeclarations
      / TopLevelComptime ContainerDeclarations
@@ -22,7 +24,9 @@ FnProto <- KEYWORD_fn IDENTIFIER? LPAREN ParamDeclList RPAREN ByteAlign? LinkSec
 
 VarDecl <- (KEYWORD_const / KEYWORD_var) IDENTIFIER (COLON TypeExpr)? ByteAlign? LinkSection? (EQUAL Expr)? SEMICOLON
 
-ContainerField <- doc_comment? KEYWORD_comptime? IDENTIFIER (COLON (KEYWORD_anytype / TypeExpr) ByteAlign?)? (EQUAL Expr)?
+ContainerField <- doc_comment? KEYWORD_comptime? IDENTIFIER COLON (KEYWORD_anytype / TypeExpr) ByteAlign? (EQUAL Expr)?
+
+EnumField <- doc_comment? IDENTIFIER (EQUAL Expr)?
 
 # *** Block Level ***
 Statement
@@ -307,12 +311,13 @@ PtrTypeStart
 ArrayTypeStart <- LBRACKET Expr (COLON Expr)? RBRACKET
 
 # ContainerDecl specific
-ContainerDeclAuto <- ContainerDeclType LBRACE container_doc_comment? ContainerMembers RBRACE
+ContainerDeclAuto
+    <- ContainerDeclType LBRACE container_doc_comment? ContainerMembers RBRACE
+     / KEYWORD_enum (LPAREN Expr RPAREN)? LBRACE container_doc_comment? EnumMembers RBRACE
 
 ContainerDeclType
     <- KEYWORD_struct
      / KEYWORD_opaque
-     / KEYWORD_enum (LPAREN Expr RPAREN)?
      / KEYWORD_union (LPAREN (KEYWORD_enum (LPAREN Expr RPAREN)? / Expr) RPAREN)?
 
 # Alignment
@@ -334,6 +339,8 @@ ParamDeclList <- (ParamDecl COMMA)* ParamDecl?
 ExprList <- (Expr COMMA)* Expr?
 
 ContainerFieldList <- (ContainerField COMMA)* ContainerField?
+
+EnumFieldList <- (EnumField COMMA)* EnumField?
 
 # *** Tokens ***
 eof <- !.

--- a/grammar/grammar.y
+++ b/grammar/grammar.y
@@ -1,15 +1,15 @@
 Root <- skip container_doc_comment? StructMembers eof
 
 # *** Top level ***
-StructMembers <- ContainerDeclarations StructFieldList ContainerDeclarations
+StructMembers <- ContainerDeclarations (StructField COMMA)* (StructField / ContainerDeclarations)
 
-BareUnionMembers <- ContainerDeclarations BareUnionFieldList ContainerDeclarations
+BareUnionMembers <- ContainerDeclarations (BareUnionField COMMA)* (BareUnionField / ContainerDeclarations)
 
-InferredTagUnionMembers <- ContainerDeclarations InferredTagUnionFieldList ContainerDeclarations
+InferredTagUnionMembers <- ContainerDeclarations (InferredTagUnionField COMMA)* (InferredTagUnionField / ContainerDeclarations)
 
-ExplicitTagUnionMembers <- ContainerDeclarations ExplicitTagUnionFieldList ContainerDeclarations
+ExplicitTagUnionMembers <- ContainerDeclarations (ExplicitTagUnionField COMMA)* (ExplicitTagUnionField / ContainerDeclarations)
 
-EnumMembers <- ContainerDeclarations EnumFieldList ContainerDeclarations
+EnumMembers <- ContainerDeclarations (EnumField COMMA)* (EnumField / ContainerDeclarations)
 
 ContainerDeclarations
     <- TestDecl ContainerDeclarations
@@ -348,16 +348,6 @@ StringList <- (STRINGLITERAL COMMA)* STRINGLITERAL?
 ParamDeclList <- (ParamDecl COMMA)* ParamDecl?
 
 ExprList <- (Expr COMMA)* Expr?
-
-StructFieldList <- (StructField COMMA)* StructField?
-
-BareUnionFieldList <- (BareUnionField COMMA)* BareUnionField?
-
-InferredTagUnionFieldList <- (InferredTagUnionField COMMA)* InferredTagUnionField?
-
-ExplicitTagUnionFieldList <- (ExplicitTagUnionField COMMA)* ExplicitTagUnionField?
-
-EnumFieldList <- (EnumField COMMA)* EnumField?
 
 # *** Tokens ***
 eof <- !.

--- a/grammar/tests/invalid_fields.zig
+++ b/grammar/tests/invalid_fields.zig
@@ -1,0 +1,14 @@
+// always require types on fields in structs
+const T = struct { a };
+
+// don't allow types to be specified here
+const E = enum { a: u32, b };
+
+// always require types on fields in bare unions
+const U1 = union { a }; 
+
+// types may be present or omitted in unions with explicit tag but not tag assigments
+const U2 = union(E) { a: u32 = 0, b };
+
+// types may be present or omitted in unions with implicit tag and tag assigments are ok
+const U3 = union(enum) { a: u32 = 0, b };


### PR DESCRIPTION
The grammar should be more specific about what kind of fields a container allows. struct and untagged union containers should mandate types for fields, whereas tagged union containers may omit the type. Further, enum containers should not allow types for fields at all. Examples:

```
const T = struct { a: u32 }; // always require types on fields in structs
const E = enum { a, b }; // don't allow types to be specified here
const U1 = union { a: u32 }; // always require types on fields in untagged unions
const U2 = union(E) { a: u32, b } // types may be present or omitted in tagged unions
```

This requires separating `ContainerMembers` from the new `EnumMembers` and `TaggedUnionMembers` nonterminals. To reduce duplication, container declarations are first pulled out into a new nonterminal, `ContainerDeclarations`. This also allows making the mixing of declarations in between container fields a parse error: all containers have a possibly empty prefix of declarations, followed by a possibly empty list of fields, followed by a possibly empty suffix of declarations.

All tests (expecting the `invalid_` ones) pass except for async_fn.zig, which was already failing before these changes.