### PR TITLE
separate container declarations from fields and disallow declarations between fields

### DIFF
--- a/grammar/grammar.y
+++ b/grammar/grammar.y
@@ -1,15 +1,13 @@
 Root <- skip container_doc_comment? ContainerMembers eof
 
 # *** Top level ***
-ContainerMembers
-    <- (
-         TestDecl ContainerMembers
-         / TopLevelComptime ContainerMembers
-         / doc_comment? KEYWORD_pub? TopLevelDecl ContainerMembers
-         / ContainerField COMMA ContainerMembers
-         / ContainerField
-         /
-     )
+ContainerMembers <- ContainerDeclarations (ContainerField COMMA)* (ContainerField / ContainerDeclarations)
+
+ContainerDeclarations
+    <- TestDecl ContainerDeclarations
+     / TopLevelComptime ContainerDeclarations
+     / doc_comment? KEYWORD_pub? TopLevelDecl ContainerDeclarations
+     /
 
 TestDecl <- doc_comment? KEYWORD_test STRINGLITERALSINGLE? Block
 

--- a/grammar/tests/invalid_declaration_after_field.zig
+++ b/grammar/tests/invalid_declaration_after_field.zig
@@ -1,0 +1,6 @@
+const T = struct {
+    const a: u32 = 10;
+    b: u32,
+    c: u32
+    const d: u32 = 11;
+};


### PR DESCRIPTION
Following the discussion in https://github.com/ziglang/zig-spec/pull/32, it was decided that changing the grammar to disallow declarations between fields is a good idea. I also added a new test to ensure declarations can only follow a field with a trailing comma.