### PR TITLE
grammar: improve the IDENTIFIER rule

### DIFF
--- a/grammar/grammar.y
+++ b/grammar/grammar.y
@@ -432,7 +432,7 @@ STRINGLITERAL
      / (line_string                 skip)+
 IDENTIFIER
     <- !keyword [A-Za-z_] [A-Za-z0-9_]* skip
-     / "@\"" string_char* "\""                            skip
+     / "@" STRINGLITERALSINGLE
 BUILTINIDENTIFIER <- "@"[A-Za-z_][A-Za-z0-9_]* skip
 
 


### PR DESCRIPTION
In the IDENTIFIER rule, use the simpler `"@" STRINGLITERALSINGLE` parsing expression.