### PR TITLE
Simplify PEG syntax in grammar

### DIFF
--- a/grammar/grammar.y
+++ b/grammar/grammar.y
@@ -408,7 +408,9 @@ mb_utf8_literal <-
      / oxE0      oxA0_oxBF ox80_oxBF
      / oxC2_oxDF ox80_oxBF
 
-ascii_char_not_nl_slash_squote <- [\000-\011\013-\046\050-\133\135-\177]
+# NOTE: `\135` is `]`. We separate to avoid this: [\000-\011\013-\046\050-\133]-\177]
+#                                                 ^                           ^XXXXXX
+ascii_char_not_nl_slash_squote <- [\000-\011\013-\046\050-\133\136-\177] / ']'
 
 char_escape
     <- "\\x" hex hex

--- a/grammar/grammar.y
+++ b/grammar/grammar.y
@@ -426,28 +426,28 @@ string_char
 container_doc_comment <- ('//!' [^\n]* [ \n]* skip)+
 doc_comment <- ('///' [^\n]* [ \n]* skip)+
 line_comment <- '//' ![!/][^\n]* / '////' [^\n]*
-line_string <- ("\\\\" [^\n]* [ \n]*)+
+line_string <- ('\\\\' [^\n]* [ \n]*)+
 skip <- ([ \n] / line_comment)*
 
-CHAR_LITERAL <- "'" char_char "'" skip
+CHAR_LITERAL <- ['] char_char ['] skip
 FLOAT
-    <- "0x" hex_int "." hex_int ([pP] [-+]? dec_int)? skip
-     /      dec_int "." dec_int ([eE] [-+]? dec_int)? skip
-     / "0x" hex_int [pP] [-+]? dec_int skip
+    <- '0x' hex_int '.' hex_int ([pP] [-+]? dec_int)? skip
+     /      dec_int '.' dec_int ([eE] [-+]? dec_int)? skip
+     / '0x' hex_int [pP] [-+]? dec_int skip
      /      dec_int [eE] [-+]? dec_int skip
 INTEGER
-    <- "0b" bin_int skip
-     / "0o" oct_int skip
-     / "0x" hex_int skip
+    <- '0b' bin_int skip
+     / '0o' oct_int skip
+     / '0x' hex_int skip
      /      dec_int   skip
-STRINGLITERALSINGLE <- "\"" string_char* "\"" skip
+STRINGLITERALSINGLE <- ["] string_char* ["] skip
 STRINGLITERAL
     <- STRINGLITERALSINGLE
      / (line_string                 skip)+
 IDENTIFIER
     <- !keyword [A-Za-z_] [A-Za-z0-9_]* skip
-     / "@" STRINGLITERALSINGLE
-BUILTINIDENTIFIER <- "@"[A-Za-z_][A-Za-z0-9_]* skip
+     / '@' STRINGLITERALSINGLE
+BUILTINIDENTIFIER <- '@'[A-Za-z_][A-Za-z0-9_]* skip
 
 
 AMPERSAND            <- '&'      ![=]      skip


### PR DESCRIPTION
It passes the same amount of tests than the original one, but it reduces a couple of problems I've encountered on simple PEG implementations (specially in [Guile's](https://www.gnu.org/software/guile/manual/guile.html#PEG-Syntax-Reference)):

- Using quotes for terminals
- A possible misparse of the ]

There are other things that might surprise people that use this grammar that I didn't touch:

- Using underscores in identifiers are not always supported
- The escape codes don't work in every PEG parsers
- Comments either

But I think those are fine and we shouldn't change them.